### PR TITLE
feat(wallet): validate native and spl transfer's recipient account

### DIFF
--- a/libs/application/wallets/features/native-transfer/src/lib/native-transfer.store.ts
+++ b/libs/application/wallets/features/native-transfer/src/lib/native-transfer.store.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@angular/core';
+import { ComponentStore, tapResponse } from '@ngrx/component-store';
+import { isNotNull } from '@nx-dapp/shared/utils/operators';
+import {
+  SolanaDappAccountService,
+  TokenAccount,
+} from '@nx-dapp/solana-dapp/angular';
+import { PublicKey } from '@solana/web3.js';
+import { Observable } from 'rxjs';
+import { concatMap, tap } from 'rxjs/operators';
+
+export interface ViewModel {
+  recipientAddress: string | null;
+  recipientAccount: TokenAccount | null;
+  loading: boolean;
+}
+
+@Injectable()
+export class NativeTransferStore extends ComponentStore<ViewModel> {
+  readonly recipientAddress$ = this.select((state) => state.recipientAddress);
+  readonly recipientAccount$ = this.select((state) => state.recipientAccount);
+  readonly loading$ = this.select((state) => state.loading);
+
+  constructor(private accountService: SolanaDappAccountService) {
+    super({
+      recipientAddress: null,
+      recipientAccount: null,
+      loading: false,
+    });
+  }
+
+  readonly setRecipientAccount = this.updater(
+    (state, recipientAccount: TokenAccount | null) => ({
+      ...state,
+      recipientAccount,
+      loading: true,
+    })
+  );
+
+  readonly setRecipientAddress = this.updater(
+    (state, recipientAddress: string | null) => ({
+      ...state,
+      loading: false,
+      recipientAddress,
+      recipientAccount: null,
+    })
+  );
+
+  readonly getRecipientAccount = this.effect(
+    (recipientAddress$: Observable<string | null>) =>
+      recipientAddress$.pipe(
+        tap((recipientAddress) => this.setRecipientAddress(recipientAddress)),
+        isNotNull,
+        concatMap((recipientAddress) =>
+          this.accountService.getNativeAccount(new PublicKey(recipientAddress))
+        ),
+        tapResponse(
+          (recipientAccount) => this.setRecipientAccount(recipientAccount),
+          (error) => this.logError(error)
+        )
+      )
+  );
+
+  readonly clearRecipientAccount = this.effect(
+    (recipientAddress$: Observable<string | null>) =>
+      recipientAddress$.pipe(
+        tapResponse(
+          () => this.setRecipientAccount(null),
+          (error) => this.logError(error)
+        )
+      )
+  );
+
+  private logError(error: unknown) {
+    console.error(error);
+  }
+
+  init(
+    validRecipientAddress$: Observable<string>,
+    invalidRecipientAddress$: Observable<string>
+  ) {
+    this.getRecipientAccount(validRecipientAddress$);
+    this.clearRecipientAccount(invalidRecipientAddress$);
+  }
+}

--- a/libs/application/wallets/features/spl-transfer/src/lib/spl-transfer.component.ts
+++ b/libs/application/wallets/features/spl-transfer/src/lib/spl-transfer.component.ts
@@ -23,7 +23,7 @@ import { SplTransferData } from './types';
       <p>Complete the form and hit send.</p>
     </header>
 
-    <form [formGroup]="sendFundsGroup" class="flex flex-col gap-4">
+    <form [formGroup]="splTransferGroup" class="flex flex-col gap-4">
       <mat-form-field class="w-full" appearance="fill">
         <mat-label>Recipient</mat-label>
         <input
@@ -65,7 +65,8 @@ import { SplTransferData } from './types';
         *ngIf="
           submitted &&
           recipientAddressControl.valid &&
-          associatedTokenAccountControl?.errors?.required
+          (loading$ | async) === false &&
+          (associatedTokenAccount$ | async) === null
         "
         class="text-center text-warn text-xs m-0"
       >
@@ -77,7 +78,7 @@ import { SplTransferData } from './types';
         color="primary"
         (click)="onSend()"
         class="w-full"
-        [disabled]="submitted && sendFundsGroup.invalid"
+        [disabled]="submitted && splTransferGroup.invalid"
       >
         Send funds
       </button>
@@ -105,8 +106,10 @@ import { SplTransferData } from './types';
 export class SplTransferComponent implements OnInit, OnDestroy {
   @HostBinding('class') class = 'block w-72 relative';
   private readonly _destroy = new Subject();
+  loading$ = this.splTransferStore.loading$;
+  associatedTokenAccount$ = this.splTransferStore.associatedTokenAccount$;
   submitted = false;
-  sendFundsGroup = new FormGroup({
+  splTransferGroup = new FormGroup({
     recipientAddress: new FormControl('', [
       Validators.required,
       base58Validator,
@@ -118,15 +121,15 @@ export class SplTransferComponent implements OnInit, OnDestroy {
   });
 
   get recipientAddressControl() {
-    return this.sendFundsGroup.get('recipientAddress') as FormControl;
+    return this.splTransferGroup.get('recipientAddress') as FormControl;
   }
 
   get amountControl() {
-    return this.sendFundsGroup.get('amount') as FormControl;
+    return this.splTransferGroup.get('amount') as FormControl;
   }
 
   get associatedTokenAccountControl() {
-    return this.sendFundsGroup.get('associatedTokenAccount') as FormControl;
+    return this.splTransferGroup.get('associatedTokenAccount') as FormControl;
   }
 
   constructor(
@@ -160,9 +163,9 @@ export class SplTransferComponent implements OnInit, OnDestroy {
 
   onSend() {
     this.submitted = true;
-    this.sendFundsGroup.markAllAsTouched();
+    this.splTransferGroup.markAllAsTouched();
 
-    if (this.sendFundsGroup.valid) {
+    if (this.splTransferGroup.valid) {
       this.splTransferStore.sendTransfer(this.amountControl.value);
       this.dialogRef.close();
     }

--- a/libs/solana-dapp/account/src/lib/get-token-account.ts
+++ b/libs/solana-dapp/account/src/lib/get-token-account.ts
@@ -7,11 +7,12 @@ import { getAccount } from '..';
 
 export const getTokenAccount = (
   connection: Connection,
-  pubkey: PublicKey,
+  publicKey: PublicKey,
   commitment?: Commitment
 ): Observable<TokenAccount | null> =>
-  getAccount(connection, pubkey, commitment || 'recent').pipe(
+  getAccount(connection, publicKey, commitment || 'recent').pipe(
     map(
-      (tokenAccount) => tokenAccount && TokenAccountParser(pubkey, tokenAccount)
+      (tokenAccount) =>
+        tokenAccount && TokenAccountParser(publicKey, tokenAccount)
     )
   );

--- a/libs/solana-dapp/angular/src/lib/services/account.service.ts
+++ b/libs/solana-dapp/angular/src/lib/services/account.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { getTokenAccount, TokenAccount } from '@nx-dapp/solana-dapp/account';
+import {
+  getNativeAccount,
+  getTokenAccount,
+  TokenAccount,
+} from '@nx-dapp/solana-dapp/account';
 import { PublicKey } from '@solana/web3.js';
 import { Observable } from 'rxjs';
 import { concatMap, first } from 'rxjs/operators';
@@ -14,6 +18,13 @@ export class SolanaDappAccountService {
     return this.connectionService.connection$.pipe(
       first(),
       concatMap((connection) => getTokenAccount(connection, publicKey))
+    );
+  }
+
+  getNativeAccount(publicKey: PublicKey): Observable<TokenAccount | null> {
+    return this.connectionService.connection$.pipe(
+      first(),
+      concatMap((connection) => getNativeAccount(connection, publicKey))
     );
   }
 }


### PR DESCRIPTION
For Native it includes a new store to manage the state, in spl it just took some adjustment so both (native and spl) are similar.

closes #59 